### PR TITLE
비밀번호 변경 API 구현

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -20,6 +20,7 @@
         "morgan": "^1.10.1",
         "multer": "^2.0.2",
         "mysql2": "^3.16.0",
+        "nodemailer": "^8.0.1",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
@@ -1234,6 +1235,15 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "morgan": "^1.10.1",
     "multer": "^2.0.2",
     "mysql2": "^3.16.0",
+    "nodemailer": "^8.0.1",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "passport-local": "^1.0.0",

--- a/app/src/auth/auth.controller.js
+++ b/app/src/auth/auth.controller.js
@@ -86,40 +86,11 @@ class AuthController {
     }
   };
 
-  forgotPassword = async (req, res, next) => {
-    try {
-      const { email } = req.body;
-
-      await this.authService.forgotPassword(email);
-
-      res.status(200).json({
-        message: "비밀번호 재설정 링크가 이메일로 전송되었습니다.",
-      });
-    } catch (error) {
-      next(error);
-    }
-  };
-
-  verifyResetToken = async (req, res, next) => {
-    try {
-      const { token } = req.params;
-
-      await this.authService.verifyResetToken(token);
-
-      res.status(200).json({
-        message: "유효한 토큰입니다.",
-      });
-    } catch (error) {
-      next(error);
-    }
-  };
-
   resetPassword = async (req, res, next) => {
     try {
-      const { token } = req.params;
-      const { password } = req.body;
+      const { email, password } = req.body;
 
-      await this.authService.resetPassword(token, password);
+      await this.authService.resetPassword(email, password);
 
       res.status(200).json({
         message: "비밀번호가 성공적으로 변경되었습니다.",

--- a/app/src/auth/auth.controller.js
+++ b/app/src/auth/auth.controller.js
@@ -85,6 +85,49 @@ class AuthController {
       next(error);
     }
   };
+
+  forgotPassword = async (req, res, next) => {
+    try {
+      const { email } = req.body;
+
+      await this.authService.forgotPassword(email);
+
+      res.status(200).json({
+        message: "비밀번호 재설정 링크가 이메일로 전송되었습니다.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  verifyResetToken = async (req, res, next) => {
+    try {
+      const { token } = req.params;
+
+      await this.authService.verifyResetToken(token);
+
+      res.status(200).json({
+        message: "유효한 토큰입니다.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  resetPassword = async (req, res, next) => {
+    try {
+      const { token } = req.params;
+      const { password } = req.body;
+
+      await this.authService.resetPassword(token, password);
+
+      res.status(200).json({
+        message: "비밀번호가 성공적으로 변경되었습니다.",
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
 }
 
 module.exports = AuthController;

--- a/app/src/auth/auth.service.js
+++ b/app/src/auth/auth.service.js
@@ -84,7 +84,7 @@ class AuthService {
     }
 
     const resetToken = crypto.randomBytes(32).toString("hex");
-    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    const expiresAt = new Date(Date.now() + jwtConfig.resetPasswordTokenExpires);
 
     await this.userService.updateResetToken(user.id, resetToken, expiresAt);
     await sendPasswordResetEmail(email, resetToken);

--- a/app/src/auth/auth.service.js
+++ b/app/src/auth/auth.service.js
@@ -2,9 +2,7 @@
 
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
-const crypto = require("crypto");
 const jwtConfig = require("../config/jwt");
-const { sendPasswordResetEmail, sendPasswordChangedEmail } = require("../utils/email.util");
 
 const CustomError = require("./../utils/customError");
 
@@ -77,52 +75,22 @@ class AuthService {
     return await this.userService.removeRefreshToken(token);
   }
 
-  async forgotPassword(email) {
+  async resetPassword(email, newPassword) {
     const user = await this.userService.findUserByEmail(email);
-    if (!user) {
-      return true;
-    }
-
-    const resetToken = crypto.randomBytes(32).toString("hex");
-    const expiresAt = new Date(Date.now() + jwtConfig.resetPasswordTokenExpires);
-
-    await this.userService.updateResetToken(user.id, resetToken, expiresAt);
-    await sendPasswordResetEmail(email, resetToken);
-
-    return true;
-  }
-
-  async verifyResetToken(token) {
-    const user = await this.userService.findUserByResetToken(token);
 
     if (!user) {
-      throw new CustomError("유효하지 않거나 만료된 토큰입니다.", 400);
+      throw new CustomError("해당 이메일로 가입된 계정을 찾을 수 없습니다.", 404);
     }
-
-    return user;
-  }
-
-  async resetPassword(token, newPassword) {
-    const user = await this.verifyResetToken(token);
 
     const hashedPassword = await bcrypt.hash(newPassword, 10);
 
-    const isUpdated = await this.userService.updatePasswordAndClearToken(
-      user.id,
-      hashedPassword
-    );
+    const isUpdated = await this.userService.updatePassword(user.id, hashedPassword);
 
     if (!isUpdated) {
       throw new CustomError("비밀번호 변경에 실패했습니다.", 500);
     }
 
     await this.userService.removeAllRefreshTokensByUserId(user.id);
-
-    try {
-      await sendPasswordChangedEmail(user.email);
-    } catch (error) {
-      console.error("비밀번호 변경 알림 이메일 발송 실패:", error);
-    }
 
     return true;
   }

--- a/app/src/auth/auth.service.js
+++ b/app/src/auth/auth.service.js
@@ -2,7 +2,9 @@
 
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+const crypto = require("crypto");
 const jwtConfig = require("../config/jwt");
+const { sendPasswordResetEmail, sendPasswordChangedEmail } = require("../utils/email.util");
 
 const CustomError = require("./../utils/customError");
 
@@ -73,6 +75,56 @@ class AuthService {
 
   async logout(token) {
     return await this.userService.removeRefreshToken(token);
+  }
+
+  async forgotPassword(email) {
+    const user = await this.userService.findUserByEmail(email);
+    if (!user) {
+      return true;
+    }
+
+    const resetToken = crypto.randomBytes(32).toString("hex");
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+    await this.userService.updateResetToken(user.id, resetToken, expiresAt);
+    await sendPasswordResetEmail(email, resetToken);
+
+    return true;
+  }
+
+  async verifyResetToken(token) {
+    const user = await this.userService.findUserByResetToken(token);
+
+    if (!user) {
+      throw new CustomError("유효하지 않거나 만료된 토큰입니다.", 400);
+    }
+
+    return user;
+  }
+
+  async resetPassword(token, newPassword) {
+    const user = await this.verifyResetToken(token);
+
+    const hashedPassword = await bcrypt.hash(newPassword, 10);
+
+    const isUpdated = await this.userService.updatePasswordAndClearToken(
+      user.id,
+      hashedPassword
+    );
+
+    if (!isUpdated) {
+      throw new CustomError("비밀번호 변경에 실패했습니다.", 500);
+    }
+
+    await this.userService.removeAllRefreshTokensByUserId(user.id);
+
+    try {
+      await sendPasswordChangedEmail(user.email);
+    } catch (error) {
+      console.error("비밀번호 변경 알림 이메일 발송 실패:", error);
+    }
+
+    return true;
   }
 }
 

--- a/app/src/config/email.js
+++ b/app/src/config/email.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const SMTP_CONFIGS = {
+  gmail: {
+    service: "gmail",
+  },
+  naver: {
+    host: "smtp.naver.com",
+    port: 465,
+    secure: true,
+  },
+};
+
+module.exports = {
+  service: process.env.EMAIL_SERVICE || "gmail",
+
+  getSmtpConfig() {
+    const serviceType = this.service.toLowerCase();
+    return SMTP_CONFIGS[serviceType] || SMTP_CONFIGS.gmail;
+  },
+
+  user: process.env.EMAIL_USER,
+  pass: process.env.EMAIL_PASS,
+  baseUrl: process.env.BASE_URL || "http://localhost:3000",
+  from: process.env.EMAIL_FROM || "ClubService",
+};

--- a/app/src/config/jwt.js
+++ b/app/src/config/jwt.js
@@ -4,4 +4,6 @@ module.exports = {
 
   accessExpiresIn: process.env.ACCESS_EXPIRES,
   refreshExpiresIn: process.env.REFRESH_EXPIRES,
+
+  resetPasswordTokenExpires: 60 * 60 * 1000,
 };

--- a/app/src/routes/auth.js
+++ b/app/src/routes/auth.js
@@ -3,8 +3,6 @@
 const express = require("express");
 const {
   signupValidator,
-  forgotPasswordValidator,
-  verifyResetTokenValidator,
   resetPasswordValidator,
 } = require("../validators/auth.validator");
 const validate = require("../middleware/validate");
@@ -26,20 +24,8 @@ router.post("/login", authController.login);
 router.post("/logout", authGuard(), authController.logout);
 router.post("/refresh", authController.refresh);
 
-router.post(
-  "/forgot-password",
-  forgotPasswordValidator,
-  validate,
-  authController.forgotPassword
-);
-router.get(
-  "/reset-password/:token",
-  verifyResetTokenValidator,
-  validate,
-  authController.verifyResetToken
-);
 router.patch(
-  "/reset-password/:token",
+  "/reset-password",
   resetPasswordValidator,
   validate,
   authController.resetPassword

--- a/app/src/routes/auth.js
+++ b/app/src/routes/auth.js
@@ -1,7 +1,12 @@
 "use strict";
 
 const express = require("express");
-const { signupValidator } = require("../validators/auth.validator");
+const {
+  signupValidator,
+  forgotPasswordValidator,
+  verifyResetTokenValidator,
+  resetPasswordValidator,
+} = require("../validators/auth.validator");
 const validate = require("../middleware/validate");
 
 const AuthService = require("./../auth/auth.service");
@@ -20,5 +25,24 @@ router.post("/signup", signupValidator, validate, authController.signup);
 router.post("/login", authController.login);
 router.post("/logout", authGuard(), authController.logout);
 router.post("/refresh", authController.refresh);
+
+router.post(
+  "/forgot-password",
+  forgotPasswordValidator,
+  validate,
+  authController.forgotPassword
+);
+router.get(
+  "/reset-password/:token",
+  verifyResetTokenValidator,
+  validate,
+  authController.verifyResetToken
+);
+router.patch(
+  "/reset-password/:token",
+  resetPasswordValidator,
+  validate,
+  authController.resetPassword
+);
 
 module.exports = router;

--- a/app/src/users/user.repository.js
+++ b/app/src/users/user.repository.js
@@ -164,6 +164,12 @@ class UserRepository {
     return rows.affectedRows > 0;
   }
 
+  async updatePassword(userId, hashedPassword) {
+    const query = "UPDATE users SET password = ? WHERE id = ?";
+    const rows = await execute(query, [hashedPassword, userId]);
+    return rows.affectedRows > 0;
+  }
+
   async removeAllRefreshTokensByUserId(userId) {
     const query = "DELETE FROM refresh_token WHERE user_id = ?";
     const rows = await execute(query, [userId]);

--- a/app/src/users/user.repository.js
+++ b/app/src/users/user.repository.js
@@ -130,6 +130,45 @@ class UserRepository {
     `;
     await execute(query, [followerId, followingId]);
   }
+
+  async updateResetToken(userId, token, expiresAt) {
+    const query = `
+      UPDATE users
+      SET reset_password_token = ?, reset_password_expires = ?
+      WHERE id = ?
+    `;
+    const rows = await execute(query, [token, expiresAt, userId]);
+    return rows.affectedRows > 0;
+  }
+
+  async findUserByResetToken(token) {
+    const query = `
+      SELECT * FROM users
+      WHERE reset_password_token = ?
+        AND reset_password_expires > NOW()
+    `;
+    const rows = await execute(query, [token]);
+    const result = camelcaseKeys(rows, { deep: true });
+    return result[0] || null;
+  }
+
+  async updatePasswordAndClearToken(userId, hashedPassword) {
+    const query = `
+      UPDATE users
+      SET password = ?,
+          reset_password_token = NULL,
+          reset_password_expires = NULL
+      WHERE id = ?
+    `;
+    const rows = await execute(query, [hashedPassword, userId]);
+    return rows.affectedRows > 0;
+  }
+
+  async removeAllRefreshTokensByUserId(userId) {
+    const query = "DELETE FROM refresh_token WHERE user_id = ?";
+    const rows = await execute(query, [userId]);
+    return rows.affectedRows >= 0;
+  }
 }
 
 module.exports = UserRepository;

--- a/app/src/users/user.service.js
+++ b/app/src/users/user.service.js
@@ -117,6 +117,10 @@ class UserService {
     return await this.userRepository.updatePasswordAndClearToken(userId, hashedPassword);
   }
 
+  async updatePassword(userId, hashedPassword) {
+    return await this.userRepository.updatePassword(userId, hashedPassword);
+  }
+
   async removeAllRefreshTokensByUserId(userId) {
     return await this.userRepository.removeAllRefreshTokensByUserId(userId);
   }

--- a/app/src/users/user.service.js
+++ b/app/src/users/user.service.js
@@ -104,6 +104,22 @@ class UserService {
 
     await this.userRepository.deleteFollow(followerId, targetId);
   }
+
+  async updateResetToken(userId, token, expiresAt) {
+    return await this.userRepository.updateResetToken(userId, token, expiresAt);
+  }
+
+  async findUserByResetToken(token) {
+    return await this.userRepository.findUserByResetToken(token);
+  }
+
+  async updatePasswordAndClearToken(userId, hashedPassword) {
+    return await this.userRepository.updatePasswordAndClearToken(userId, hashedPassword);
+  }
+
+  async removeAllRefreshTokensByUserId(userId) {
+    return await this.userRepository.removeAllRefreshTokensByUserId(userId);
+  }
 }
 
 module.exports = UserService;

--- a/app/src/utils/email.util.js
+++ b/app/src/utils/email.util.js
@@ -1,0 +1,123 @@
+"use strict";
+
+const nodemailer = require("nodemailer");
+const emailConfig = require("../config/email");
+
+const createTransporter = () => {
+  const smtpConfig = emailConfig.getSmtpConfig();
+
+  if (emailConfig.service.toLowerCase() === "gmail") {
+    return nodemailer.createTransport({
+      service: smtpConfig.service,
+      auth: {
+        user: emailConfig.user,
+        pass: emailConfig.pass,
+      },
+    });
+  }
+
+  return nodemailer.createTransport({
+    host: smtpConfig.host,
+    port: smtpConfig.port,
+    secure: smtpConfig.secure,
+    auth: {
+      user: emailConfig.user,
+      pass: emailConfig.pass,
+    },
+  });
+};
+
+const sendPasswordResetEmail = async (email, token) => {
+  try {
+    const transporter = createTransporter();
+    const resetUrl = `${emailConfig.baseUrl}/reset-password/${token}`;
+
+    const mailOptions = {
+      from: `"${emailConfig.from}" <${emailConfig.user}>`,
+      to: email,
+      subject: "비밀번호 재설정 요청",
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color: #333;">비밀번호 재설정</h2>
+          <p>비밀번호 재설정을 요청하셨습니다.</p>
+          <p>아래 버튼을 클릭하여 비밀번호를 재설정하세요.</p>
+          <div style="margin: 30px 0;">
+            <a href="${resetUrl}"
+               style="background-color: #4CAF50;
+                      color: white;
+                      padding: 12px 24px;
+                      text-decoration: none;
+                      border-radius: 4px;
+                      display: inline-block;">
+              비밀번호 재설정하기
+            </a>
+          </div>
+          <p style="color: #666; font-size: 14px;">
+            또는 아래 링크를 복사하여 브라우저에 붙여넣으세요:
+          </p>
+          <p style="color: #007bff; word-break: break-all;">
+            ${resetUrl}
+          </p>
+          <hr style="border: none; border-top: 1px solid #eee; margin: 30px 0;">
+          <p style="color: #999; font-size: 12px;">
+            이 링크는 <strong>1시간 동안만 유효</strong>합니다.<br>
+            비밀번호 재설정을 요청하지 않으셨다면, 이 이메일을 무시하세요.
+          </p>
+        </div>
+      `,
+      text: `
+        비밀번호 재설정을 요청하셨습니다.
+
+        아래 링크를 클릭하여 비밀번호를 재설정하세요:
+        ${resetUrl}
+
+        이 링크는 1시간 동안만 유효합니다.
+        비밀번호 재설정을 요청하지 않으셨다면, 이 이메일을 무시하세요.
+      `,
+    };
+
+    await transporter.sendMail(mailOptions);
+    console.log(`비밀번호 재설정 이메일 발송 완료: ${email}`);
+    return true;
+  } catch (error) {
+    console.error("이메일 발송 실패:", error);
+    throw new Error("이메일 발송에 실패했습니다.");
+  }
+};
+
+const sendPasswordChangedEmail = async (email) => {
+  try {
+    const transporter = createTransporter();
+
+    const mailOptions = {
+      from: `"${emailConfig.from}" <${emailConfig.user}>`,
+      to: email,
+      subject: "비밀번호가 변경되었습니다",
+      html: `
+        <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+          <h2 style="color: #333;">비밀번호 변경 완료</h2>
+          <p>귀하의 계정 비밀번호가 성공적으로 변경되었습니다.</p>
+          <p style="color: #666; font-size: 14px;">
+            본인이 변경한 것이 아니라면, 즉시 고객센터로 문의해주세요.
+          </p>
+        </div>
+      `,
+      text: `
+        귀하의 계정 비밀번호가 성공적으로 변경되었습니다.
+        본인이 변경한 것이 아니라면, 즉시 고객센터로 문의해주세요.
+      `,
+    };
+
+    await transporter.sendMail(mailOptions);
+    console.log(`비밀번호 변경 알림 이메일 발송 완료: ${email}`);
+    return true;
+  } catch (error) {
+    console.error("이메일 발송 실패:", error);
+    return false;
+  }
+};
+
+module.exports = {
+  sendPasswordResetEmail,
+  sendPasswordChangedEmail,
+};

--- a/app/src/validators/auth.validator.js
+++ b/app/src/validators/auth.validator.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { body, param } = require("express-validator");
+const { body } = require("express-validator");
 
 exports.signupValidator = [
   body("email").isEmail().withMessage("이메일 형식이 올바르지 않습니다.").normalizeEmail(),
@@ -14,31 +14,13 @@ exports.signupValidator = [
     .withMessage("비밀번호는 영문과 숫자를 포함해야 합니다."),
 ];
 
-exports.forgotPasswordValidator = [
+exports.resetPasswordValidator = [
   body("email")
     .exists()
     .withMessage("이메일은 필수 항목입니다.")
     .isEmail()
     .withMessage("이메일 형식이 올바르지 않습니다.")
     .normalizeEmail(),
-];
-
-exports.verifyResetTokenValidator = [
-  param("token")
-    .exists()
-    .withMessage("토큰은 필수 항목입니다.")
-    .isLength({ min: 32 })
-    .withMessage("토큰 형식이 올바르지 않습니다.")
-    .trim(),
-];
-
-exports.resetPasswordValidator = [
-  param("token")
-    .exists()
-    .withMessage("토큰은 필수 항목입니다.")
-    .isLength({ min: 32 })
-    .withMessage("토큰 형식이 올바르지 않습니다.")
-    .trim(),
 
   body("password")
     .exists()

--- a/app/src/validators/auth.validator.js
+++ b/app/src/validators/auth.validator.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { body } = require("express-validator");
+const { body, param } = require("express-validator");
 
 exports.signupValidator = [
   body("email").isEmail().withMessage("이메일 형식이 올바르지 않습니다.").normalizeEmail(),
@@ -8,6 +8,41 @@ exports.signupValidator = [
   body("nickname").isLength({ min: 2 }).withMessage("닉네임은 2자 이상 이여야 합니다.").trim(),
 
   body("password")
+    .isLength({ min: 8 })
+    .withMessage("비밀번호는 최소 8자 이상이어야 합니다.")
+    .matches(/^(?=.*[A-Za-z])(?=.*\d).+$/)
+    .withMessage("비밀번호는 영문과 숫자를 포함해야 합니다."),
+];
+
+exports.forgotPasswordValidator = [
+  body("email")
+    .exists()
+    .withMessage("이메일은 필수 항목입니다.")
+    .isEmail()
+    .withMessage("이메일 형식이 올바르지 않습니다.")
+    .normalizeEmail(),
+];
+
+exports.verifyResetTokenValidator = [
+  param("token")
+    .exists()
+    .withMessage("토큰은 필수 항목입니다.")
+    .isLength({ min: 32 })
+    .withMessage("토큰 형식이 올바르지 않습니다.")
+    .trim(),
+];
+
+exports.resetPasswordValidator = [
+  param("token")
+    .exists()
+    .withMessage("토큰은 필수 항목입니다.")
+    .isLength({ min: 32 })
+    .withMessage("토큰 형식이 올바르지 않습니다.")
+    .trim(),
+
+  body("password")
+    .exists()
+    .withMessage("비밀번호는 필수 항목입니다.")
     .isLength({ min: 8 })
     .withMessage("비밀번호는 최소 8자 이상이어야 합니다.")
     .matches(/^(?=.*[A-Za-z])(?=.*\d).+$/)


### PR DESCRIPTION
## 연관된 이슈

- #36 

## 📝 작업 내용

- [x] `users` 테이블에 `reset_password_token`, `reset_password_expires` 컬럼 추가
- [x] `nodemailer` 설정 및 메일 전송 공통 함수 구현
- [x] `forgotPassword`, `resetPassword` 핸들러 추가
- [x] `crypto` 기반 일회용 토큰 생성 및 만료 시간(1시간) 설정
- [x] 새 비밀번호 `bcrypt` 해싱 및 DB 업데이트 로직 구현
- [x] 비밀번호 변경 완료 시 해당 유저의 모든 `refresh_token` 삭제 (전체 로그아웃)
- [x] 토큰 저장, 토큰 기반 유저 조회, 비밀번호 수정 쿼리 작성
- [x] `auth.js` 라우터에 신규 엔드포인트 연결
