### PR TITLE
관심 상품 등록 구현

### DIFF
--- a/app/src/liked/liked.controller.js
+++ b/app/src/liked/liked.controller.js
@@ -1,0 +1,47 @@
+"use strict";
+
+class LikedController {
+  constructor(likedService) {
+    this.likedService = likedService;
+  }
+
+  likeProduct = async (req, res, next) => {
+    try {
+      const userId = req.user.id;
+      const { productId } = req.body;
+
+      await this.likedService.likeProduct(userId, productId);
+
+      res.status(201).json({ message: "관심 상품으로 등록되었습니다." });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  unlikeProduct = async (req, res, next) => {
+    try {
+      const userId = req.user.id;
+      const { productId } = req.body;
+
+      await this.likedService.unlikeProduct(userId, productId);
+
+      res.status(200).json({ message: "관심 상품이 해제되었습니다." });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  getLikedProducts = async (req, res, next) => {
+    try {
+      const userId = req.user.id;
+
+      const result = await this.likedService.getLikedProducts(userId);
+
+      res.status(200).json({ data: result.products, totalCnt: result.totalCnt });
+    } catch (error) {
+      next(error);
+    }
+  };
+}
+
+module.exports = LikedController;

--- a/app/src/liked/liked.repository.js
+++ b/app/src/liked/liked.repository.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const { execute } = require("../config/db");
+
+class LikedRepository {
+  async findLikedProduct(userId, productId) {
+    const query = `
+      SELECT * FROM liked_product
+      WHERE user_id = ? AND product_id = ?
+    `;
+    const rows = await execute(query, [userId, productId]);
+    return rows.length > 0;
+  }
+
+  async createLikedProduct(userId, productId) {
+    const query = `
+      INSERT INTO liked_product (user_id, product_id)
+      VALUES (?, ?)
+    `;
+    await execute(query, [userId, productId]);
+  }
+
+  async deleteLikedProduct(userId, productId) {
+    const query = `
+      DELETE FROM liked_product
+      WHERE user_id = ? AND product_id = ?
+    `;
+    await execute(query, [userId, productId]);
+  }
+
+  async findLikedProductsByUserId(userId) {
+    const query = `
+      SELECT
+        p.id AS productId,
+        p.title,
+        p.price,
+        p.sale_status AS saleStatus,
+        p.created_at AS createdAt,
+        (
+          SELECT pi.image_url
+          FROM product_images pi
+          WHERE pi.product_id = p.id AND pi.is_thumbnail = 1
+          ORDER BY pi.id ASC
+          LIMIT 1
+        ) AS imageUrl
+      FROM liked_product lp
+      JOIN products p ON lp.product_id = p.id
+      WHERE lp.user_id = ?
+        AND p.deleted_at IS NULL
+      ORDER BY p.created_at DESC
+    `;
+    const rows = await execute(query, [userId]);
+    return rows || [];
+  }
+}
+
+module.exports = LikedRepository;

--- a/app/src/liked/liked.service.js
+++ b/app/src/liked/liked.service.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const CustomError = require("../utils/customError");
+
+class LikedService {
+  constructor(likedRepository, productRepository) {
+    this.likedRepository = likedRepository;
+    this.productRepository = productRepository;
+  }
+
+  async likeProduct(userId, productId) {
+    const product = await this.productRepository.findProductById(productId);
+    if (!product) {
+      throw new CustomError("존재하지 않는 상품입니다.", 404);
+    }
+
+    if (product.userId === userId) {
+      throw new CustomError("본인의 상품은 찜할 수 없습니다.", 400);
+    }
+
+    const isAlreadyLiked = await this.likedRepository.findLikedProduct(userId, productId);
+    if (isAlreadyLiked) {
+      throw new CustomError("이미 관심 상품으로 등록된 상품입니다.", 409);
+    }
+
+    await this.likedRepository.createLikedProduct(userId, productId);
+  }
+
+  async unlikeProduct(userId, productId) {
+    const isLiked = await this.likedRepository.findLikedProduct(userId, productId);
+    if (!isLiked) {
+      throw new CustomError("관심 상품으로 등록되지 않은 상품입니다.", 404);
+    }
+
+    await this.likedRepository.deleteLikedProduct(userId, productId);
+  }
+
+  async getLikedProducts(userId) {
+    const products = await this.likedRepository.findLikedProductsByUserId(userId);
+
+    return {
+      products,
+      totalCnt: products.length,
+    };
+  }
+}
+
+module.exports = LikedService;

--- a/app/src/routes/product.js
+++ b/app/src/routes/product.js
@@ -22,6 +22,11 @@ const ProductTagRepository = require("./../productTags/productTag.repository");
 
 const SearchRepository = require("./../search/search.repository");
 
+const LikedController = require("./../liked/liked.controller");
+const LikedService = require("./../liked/liked.service");
+const LikedRepository = require("./../liked/liked.repository");
+const { likeProductValidator } = require("../validators/liked.validator");
+
 const router = express.Router();
 
 const tagRepository = new TagRepository();
@@ -46,6 +51,10 @@ const productService = new ProductService(
 );
 const productController = new ProductController(productService);
 
+const likedRepository = new LikedRepository();
+const likedService = new LikedService(likedRepository, productRepository);
+const likedController = new LikedController(likedService);
+
 router.post(
   "/",
   authGuard(),
@@ -56,6 +65,11 @@ router.post(
 );
 
 router.get("/trending", productController.findTrendingProducts);
+
+router.post("/liked", authGuard(), likeProductValidator, validate, likedController.likeProduct);
+router.delete("/liked", authGuard(), likeProductValidator, validate, likedController.unlikeProduct);
+router.get("/liked", authGuard(), likedController.getLikedProducts);
+
 router.get("/", productController.findProducts);
 router.get("/:id", productController.findProductById);
 

--- a/app/src/validators/liked.validator.js
+++ b/app/src/validators/liked.validator.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const { body } = require("express-validator");
+
+exports.likeProductValidator = [
+  body("productId")
+    .notEmpty()
+    .withMessage("상품 ID는 필수입니다.")
+    .isInt({ min: 1 })
+    .withMessage("유효한 상품 ID가 아닙니다.")
+    .toInt(),
+];


### PR DESCRIPTION
## 연관된 이슈

- #41 

## 📝 작업 내용

- [x] `POST /products/liked`, `DELETE /products/liked`, `GET /products/liked` 엔드포인트 라우트 설정
- [x] liked.controller.js에 likeProduct, unlikeProduct, getLikedProducts 컨트롤러 함수 작성
- [x] liked.service.js에 관심 상품 등록/해제/목록 조회 비즈니스 로직 구현
- [x] liked.repository.js에 findLikedProduct, createLikedProduct, deleteLikedProduct, findLikedProductsByUserId 쿼리 함수 작성
- [x] 상품 존재 여부 확인 및 본인 상품 찜 방지 로직 추가
- [x] 이미 찜한 상품 중복 등록 방지 로직 추가 (409 에러)
- [x] 찜하지 않은 상품 해제 시도 시 404 에러 핸들링
- [x] 찜 목록 조회 시 삭제된 상품 제외 및 썸네일 이미지 포함 (products, product_images JOIN)
- [x] liked.validator.js에 likeProductValidator 작성 (productId 필수, 양의 정수)
- [x] 인증 미들웨어 적용 (모든 엔드포인트)