### PR TITLE
상품 이미지 업로드 구조 변경

### DIFF
--- a/app/src/products/product.controller.js
+++ b/app/src/products/product.controller.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const CustomError = require("../utils/customError");
+const buildImagePath = require("../utils/file.util");
 
 class ProductController {
   constructor(productService) {
@@ -10,17 +11,28 @@ class ProductController {
   create = async (req, res, next) => {
     try {
       const userId = req.user.id;
-      const files = req.files ?? [];
 
       const productInfo = {
         ...req.body,
-        files,
         userId,
       };
 
       const productId = await this.productService.create(productInfo);
 
       res.status(201).json({ message: "상품 등록을 성공했습니다.", productId });
+    } catch (error) {
+      console.error(error);
+      next(error);
+    }
+  };
+
+  uploadProductImages = async (req, res, next) => {
+    try {
+      const files = req.files ?? [];
+
+      const images = files.map((file) => buildImagePath(file.filename));
+
+      res.status(200).json({ images });
     } catch (error) {
       console.error(error);
       next(error);

--- a/app/src/products/product.service.js
+++ b/app/src/products/product.service.js
@@ -2,7 +2,7 @@
 
 const transaction = require("../config/transaction");
 const CustomError = require("../utils/customError");
-const buildImagePath = require("../utils/file.util");
+const validateImagesExist = require("../utils/image.validation");
 
 const PRODUCT_COLUMNS = [
   "title",
@@ -27,7 +27,7 @@ class ProductService {
     this.categoryService = categoryService;
   }
 
-  async create({ files, ...productData }) {
+  async create({ images = [], tags = [], ...productData }) {
     return transaction(async (connection) => {
       const newProduct = await this.productRepository.create(productData, connection);
 
@@ -37,8 +37,8 @@ class ProductService {
 
       const productId = newProduct.insertId;
 
-      if (files?.length > 0) {
-        const images = files.map((file) => buildImagePath(file.filename));
+      if (images.length > 0) {
+        await validateImagesExist(images);
 
         const result = await this.productRepository.saveProductImage(productId, images, connection);
 
@@ -46,10 +46,10 @@ class ProductService {
           throw new CustomError("상품 이미지 저장 실패");
       }
 
-      const tags = [...new Set(this.#splitTag(productData.tags))];
+      const uniqueTags = [...new Set(this.#splitTag(tags))];
 
-      if (tags.length > 0) {
-        const createdTagsId = await this.tagService.createOrFindTags(tags, connection);
+      if (uniqueTags.length > 0) {
+        const createdTagsId = await this.tagService.createOrFindTags(uniqueTags, connection);
 
         const productTags = await this.productTagService.create(
           productId,

--- a/app/src/routes/product.js
+++ b/app/src/routes/product.js
@@ -40,13 +40,13 @@ const productService = new ProductService(
 );
 const productController = new ProductController(productService);
 
+router.post("/", authGuard(), createProductValidator, validate, productController.create);
+
 router.post(
-  "/",
+  "/images",
   authGuard(),
   upload.array("images", MAX_IMAGE_COUNT),
-  createProductValidator,
-  validate,
-  productController.create
+  productController.uploadProductImages
 );
 
 router.get("/", productController.findProducts);

--- a/app/src/utils/image.validation.js
+++ b/app/src/utils/image.validation.js
@@ -1,0 +1,43 @@
+"use strict";
+
+const path = require("path");
+const fs = require("fs").promises;
+const CustomError = require("./customError");
+
+const UPLOAD_URL = "/uploads/products/";
+const UPLOAD_DIR = path.join(__dirname, "..", "uploads", "products");
+
+async function validateImagesExist(imageUrls) {
+  if (!Array.isArray(imageUrls)) {
+    throw new CustomError("images는 배열이어야 합니다.", 400);
+  }
+
+  if (imageUrls.length > 15) {
+    throw new CustomError("이미지는 최대 15개까지 업로드가 가능합니다.", 400);
+  }
+
+  const uniqueUrls = [...new Set(imageUrls)];
+
+  await Promise.all(
+    uniqueUrls.map(async (url) => {
+      if (typeof url !== "string") {
+        throw new CustomError("이미지 URL 형식이 올바르지 않습니다.", 400);
+      }
+
+      if (!url.startsWith(UPLOAD_URL)) {
+        throw new CustomError("올바르지 않은 이미지 경로입니다.", 400);
+      }
+
+      const filename = path.basename(url);
+      const filePath = path.join(UPLOAD_DIR, filename);
+
+      try {
+        await fs.access(filePath);
+      } catch (error) {
+        throw new CustomError(`존재하지 않는 이미지입니다.(${filename})`, 400);
+      }
+    })
+  );
+}
+
+module.exports = validateImagesExist;


### PR DESCRIPTION
## 연관된 이슈

- #26 

## 📝 작업 내용

- [x] 상품 정보와 이미지를 한 번에 받아서 저장 -> 이미지 업로드 API와 상품 업로드 API를 분리
