### PR TITLE
검색어 정규화 및 누적 카운트 개선

### DIFF
--- a/app/src/products/product.repository.js
+++ b/app/src/products/product.repository.js
@@ -2,6 +2,7 @@
 
 const { execute } = require("./../config/db");
 const { PRODUCT_STATUS, TRENDING_CONFIG } = require("./product.constants");
+const { normalizeSearchKeyword } = require("../utils/searchKeyword.util");
 
 const QUERY = {
   FIND_ALL_PRODUCTS_QUERY: `SELECT p.id AS product_id, p.title, p.price, p.created_at, i.image_url
@@ -95,8 +96,14 @@ class ProductRepository {
         WHERE t.name = ?`;
         params.push(value);
       } else {
-        query += ` WHERE p.title LIKE ?`;
-        params.push(`%${value}%`);
+        const normalizedValue = normalizeSearchKeyword(value);
+
+        if (!normalizedValue) {
+          query += ` WHERE 1 = 0`;
+        } else {
+          query += ` WHERE REPLACE(LOWER(p.title), ' ', '') LIKE ?`;
+          params.push(`%${normalizedValue}%`);
+        }
       }
     }
 

--- a/app/src/routes/product.js
+++ b/app/src/routes/product.js
@@ -20,6 +20,7 @@ const CategoryRepository = require("./../categories/category.repository");
 const ProductTagService = require("./../productTags/productTag.service");
 const ProductTagRepository = require("./../productTags/productTag.repository");
 
+const SearchService = require("./../search/search.service");
 const SearchRepository = require("./../search/search.repository");
 
 const router = express.Router();

--- a/app/src/search/search.repository.js
+++ b/app/src/search/search.repository.js
@@ -5,15 +5,19 @@ const { execute } = require("../config/db");
 class SearchRepository {
   async saveSearchLog(keyword, userId = null) {
     const query = `
-      INSERT INTO search_logs (keyword, user_id)
-      VALUES (?, ?)
+      INSERT INTO search_logs (keyword, user_id, search_count)
+      VALUES (?, ?, 1)
+      ON DUPLICATE KEY UPDATE
+        search_count = search_count + 1,
+        created_at = NOW(),
+        user_id = COALESCE(VALUES(user_id), user_id)
     `;
     await execute(query, [keyword, userId]);
   }
 
   async getPopularKeywords(limit = 10) {
     const query = `
-      SELECT keyword, COUNT(*) as search_count
+      SELECT keyword, SUM(search_count) AS search_count
       FROM search_logs
       WHERE created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
       GROUP BY keyword

--- a/app/src/search/search.service.js
+++ b/app/src/search/search.service.js
@@ -1,15 +1,20 @@
 "use strict";
 
+const { normalizeSearchKeyword } = require("../utils/searchKeyword.util");
+
 class SearchService {
   constructor(searchRepository) {
     this.searchRepository = searchRepository;
   }
 
   async saveSearchLog(keyword, userId = null) {
-    if (!keyword || keyword.trim() === "") {
+    const normalizedKeyword = normalizeSearchKeyword(keyword);
+
+    if (!normalizedKeyword) {
       return;
     }
-    await this.searchRepository.saveSearchLog(keyword.trim().toLowerCase(), userId);
+
+    await this.searchRepository.saveSearchLog(normalizedKeyword, userId);
   }
 
   async getPopularKeywords(limit = 10) {

--- a/app/src/utils/searchKeyword.util.js
+++ b/app/src/utils/searchKeyword.util.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const normalizeSearchKeyword = (keyword) => {
+  if (typeof keyword !== "string") return "";
+
+  return keyword.trim().toLowerCase().replace(/\s+/g, "");
+};
+
+module.exports = {
+  normalizeSearchKeyword,
+};


### PR DESCRIPTION
## 연관된 이슈

- #47 

## 📝 작업 내용

- [x] 검색어 정규화 유틸 추가 (`trim + lower + 공백 제거`)
- [x] 검색 로그 저장 시 정규화 키워드 기준으로 저장
- [x] 동일 키워드 재검색 시 신규 INSERT 대신 `search_count` 누적 증가
- [x] 인기 검색어 조회를 `COUNT(*)`에서 `SUM(search_count)` 기반으로 변경
- [x] 상품 제목 검색 시 공백 무시 매칭 적용 (`REPLACE(LOWER(title), ' ', '')`)
- [x] 빈/공백-only 검색어 입력 방어 로직 추가
- [x] 원본 DB 스키마(`docs/table_design.sql`)에 `search_count`, `keyword UNIQUE` 반영
- [x] 임시 마이그레이션 SQL 파일 삭제
