### PR TITLE
리뷰 API 이미지 입력을 form-data에서 JSON 배열로 전환

### DIFF
--- a/app/src/reviews/review.controller.js
+++ b/app/src/reviews/review.controller.js
@@ -5,21 +5,41 @@ class ReviewController {
     this.reviewService = reviewService;
   }
 
+  parseJsonArrayField = (value, fieldName) => {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    if (typeof value === "string") {
+      try {
+        const parsed = JSON.parse(value);
+
+        if (!Array.isArray(parsed)) {
+          const CustomError = require("../utils/customError");
+          throw new CustomError(`${fieldName} 형식이 올바르지 않습니다.`, 400);
+        }
+
+        return parsed;
+      } catch (error) {
+        const CustomError = require("../utils/customError");
+        throw new CustomError(`${fieldName} 형식이 올바르지 않습니다.`, 400);
+      }
+    }
+
+    const CustomError = require("../utils/customError");
+    throw new CustomError(`${fieldName} 형식이 올바르지 않습니다.`, 400);
+  };
+
   createReview = async (req, res, next) => {
     try {
       const userId = req.user.id;
-      const { sellerId, rating, content, tags, productId } = req.body;
-      const files = req.files || [];
-
-      let parsedTags = [];
-      if (tags) {
-        try {
-          parsedTags = JSON.parse(tags);
-        } catch (error) {
-          const CustomError = require("../utils/customError");
-          throw new CustomError("태그 형식이 올바르지 않습니다.", 400);
-        }
-      }
+      const { sellerId, rating, content, tags, productId, images } = req.body;
+      const parsedTags = this.parseJsonArrayField(tags, "태그") || [];
+      const parsedImages = this.parseJsonArrayField(images, "이미지") || [];
 
       const reviewId = await this.reviewService.createReview({
         userId,
@@ -28,7 +48,7 @@ class ReviewController {
         rating: Number(rating),
         content,
         tags: parsedTags,
-        files,
+        imageUrls: parsedImages,
       });
 
       res.status(201).json({
@@ -62,24 +82,15 @@ class ReviewController {
     try {
       const userId = req.user.id;
       const reviewId = Number(req.params.reviewId);
-      const { rating, content, tags } = req.body;
-      const files = req.files || [];
-
-      let parsedTags = [];
-      if (tags) {
-        try {
-          parsedTags = JSON.parse(tags);
-        } catch (error) {
-          const CustomError = require("../utils/customError");
-          throw new CustomError("태그 형식이 올바르지 않습니다.", 400);
-        }
-      }
+      const { rating, content, tags, images } = req.body;
+      const parsedTags = this.parseJsonArrayField(tags, "태그");
+      const parsedImages = this.parseJsonArrayField(images, "이미지");
 
       await this.reviewService.updateReview(userId, reviewId, {
         rating: Number(rating),
         content,
         tags: parsedTags,
-        files,
+        imageUrls: parsedImages,
       });
 
       res.status(200).json({

--- a/app/src/reviews/review.service.js
+++ b/app/src/reviews/review.service.js
@@ -2,7 +2,6 @@
 
 const transaction = require("../config/transaction");
 const CustomError = require("../utils/customError");
-const buildImagePath = require("../utils/file.util");
 
 class ReviewService {
   constructor(reviewRepository, userRepository, productRepository) {
@@ -12,7 +11,7 @@ class ReviewService {
   }
 
   async createReview(reviewData) {
-    const { userId, sellerId, productId, rating, content, tags, files } = reviewData;
+    const { userId, sellerId, productId, rating, content, tags, imageUrls } = reviewData;
 
     return transaction(async (connection) => {
       const seller = await this.userRepository.findUserById(sellerId);
@@ -63,8 +62,7 @@ class ReviewService {
         await this.reviewRepository.createReviewTags(reviewId, tags, connection);
       }
 
-      if (files && files.length > 0) {
-        const imageUrls = files.map((file) => buildImagePath(file.filename));
+      if (imageUrls && imageUrls.length > 0) {
         await this.reviewRepository.saveReviewImages(reviewId, imageUrls, connection);
       }
 
@@ -84,7 +82,7 @@ class ReviewService {
   }
 
   async updateReview(userId, reviewId, updateData) {
-    const { rating, content, tags, files } = updateData;
+    const { rating, content, tags, imageUrls } = updateData;
 
     return transaction(async (connection) => {
       const review = await this.reviewRepository.findReviewById(reviewId);
@@ -113,10 +111,9 @@ class ReviewService {
         }
       }
 
-      if (files !== undefined) {
+      if (imageUrls !== undefined) {
         await this.reviewRepository.deleteReviewImages(reviewId, connection);
-        if (files.length > 0) {
-          const imageUrls = files.map((file) => buildImagePath(file.filename));
+        if (imageUrls.length > 0) {
           await this.reviewRepository.saveReviewImages(reviewId, imageUrls, connection);
         }
       }

--- a/app/src/routes/reviews.js
+++ b/app/src/routes/reviews.js
@@ -16,7 +16,6 @@ const {
   deleteReviewValidator,
 } = require("../validators/review.validator");
 const validate = require("../middleware/validate");
-const { upload, MAX_IMAGE_COUNT } = require("../middleware/upload.middleware");
 const authGuard = require("../auth/guard/auth.guard");
 
 const router = express.Router();
@@ -33,7 +32,6 @@ router.get("/", getSellerReviewsValidator, validate, reviewController.getSellerR
 router.post(
   "/",
   authGuard(),
-  upload.array("images", 3),
   createReviewValidator,
   validate,
   reviewController.createReview
@@ -42,7 +40,6 @@ router.post(
 router.patch(
   "/:reviewId",
   authGuard(),
-  upload.array("images", 3),
   updateReviewValidator,
   validate,
   reviewController.updateReview

--- a/app/src/validators/review.validator.js
+++ b/app/src/validators/review.validator.js
@@ -53,13 +53,20 @@ exports.createReviewValidator = [
     .withMessage("유효한 상품 ID가 아닙니다.")
     .toInt(),
 
-  body().custom((value, { req }) => {
-    const files = req.files || [];
-    if (files.length > 3) {
-      throw new Error("이미지는 최대 3장까지 업로드 가능합니다.");
-    }
-    return true;
-  }),
+  body("images")
+    .optional()
+    .custom((value) => {
+      if (!Array.isArray(value)) {
+        throw new Error("images는 배열 형식이어야 합니다.");
+      }
+      if (value.length > 3) {
+        throw new Error("이미지는 최대 3장까지 업로드 가능합니다.");
+      }
+      if (!value.every((url) => typeof url === "string" && url.trim().length > 0)) {
+        throw new Error("유효하지 않은 이미지 URL 형식입니다.");
+      }
+      return true;
+    }),
 ];
 
 exports.getSellerReviewsValidator = [
@@ -115,13 +122,20 @@ exports.updateReviewValidator = [
       }
     }),
 
-  body().custom((value, { req }) => {
-    const files = req.files || [];
-    if (files.length > 3) {
-      throw new Error("이미지는 최대 3장까지 업로드 가능합니다.");
-    }
-    return true;
-  }),
+  body("images")
+    .optional()
+    .custom((value) => {
+      if (!Array.isArray(value)) {
+        throw new Error("images는 배열 형식이어야 합니다.");
+      }
+      if (value.length > 3) {
+        throw new Error("이미지는 최대 3장까지 업로드 가능합니다.");
+      }
+      if (!value.every((url) => typeof url === "string" && url.trim().length > 0)) {
+        throw new Error("유효하지 않은 이미지 URL 형식입니다.");
+      }
+      return true;
+    }),
 ];
 
 exports.deleteReviewValidator = [


### PR DESCRIPTION
## 연관된 이슈

- #51 

## 📝 작업 내용

- [x] 리뷰 라우트에서 파일 업로드 미들웨어 제거 (`app/src/routes/reviews.js`)
  - [x] `POST /reviews`의 `upload.array("images", 3)` 제거
  - [x] `PATCH /reviews/:reviewId`의 `upload.array("images", 3)` 제거
- [x] 리뷰 검증 로직을 JSON 입력 기준으로 변경 (`app/src/validators/review.validator.js`)
  - [x] `images` 배열 형식 검증 추가
  - [x] 최대 3개 제한 검증 추가
  - [x] 각 원소 문자열/공백 검증 추가
- [x] 리뷰 컨트롤러에서 `req.files` 의존 제거 (`app/src/reviews/review.controller.js`)
  - [x] `images` 필드를 `imageUrls`로 매핑
  - [x] `tags/images` 문자열/배열 입력 모두 파싱 가능하도록 처리
- [x] 리뷰 서비스 저장 로직 변경 (`app/src/reviews/review.service.js`)
  - [x] `files` 기반 처리 제거
  - [x] `imageUrls` 배열을 `saveReviewImages`에 직접 전달